### PR TITLE
feat(friends link): add reusable vue friend links components as better alternative replacement for original details blocks

### DIFF
--- a/.vitepress/config.mts
+++ b/.vitepress/config.mts
@@ -13,7 +13,7 @@ export default defineConfig({
       { text: 'Fuyutsuki Toya', link: '/toya-kawaii/toya' },
       { text: 'Technology', link: '/tech/tech ' },
       { text: 'Home', link: '/' },
-      { text: 'Friends', link: '/other/friends'}
+      { text: 'Friends', link: '/other/friends/index'}
     ],
 
     sidebar: [
@@ -34,7 +34,7 @@ export default defineConfig({
         text: 'Other',
         items: [
           { text: 'Blog archive', link: '/other/blog-archive' },
-          { text: 'Friends', link: '/other/friends' },
+          { text: 'Friends', link: '/other/friends/index' },
           { text: 'About me', link: '/other/about-me' },
         ]
       },

--- a/.vitepress/theme/components/Friends.vue
+++ b/.vitepress/theme/components/Friends.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { slugify } from '@mdit-vue/shared'
+
+import FriendsBase from './FriendsBase.vue'
+import type { FriendsLink } from '../types'
+
+const props = defineProps<{
+  title: string
+  noIcon?: boolean
+  items: FriendsLink[]
+}>()
+
+const formatTitle = computed(() => {
+  return slugify(props.title)
+})
+</script>
+
+<template>
+  <h2 v-if="title" :id="formatTitle" tabindex="-1">
+    {{ title }}
+    <a class="header-anchor" :href="`#${formatTitle}`" aria-hidden="true"></a>
+  </h2>
+  <div class="m-nav-links">
+    <FriendsBase v-for="item in items" :noIcon="noIcon" v-bind="item" />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.m-nav-links {
+  --m-nav-gap: 10px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  grid-row-gap: var(--m-nav-gap);
+  grid-column-gap: var(--m-nav-gap);
+  grid-auto-flow: row dense;
+  justify-content: center;
+  margin-top: var(--m-nav-gap);
+}
+
+@each $media, $size in (500px: 140px, 640px: 155px, 768px: 175px, 960px: 200px, 1440px: 240px) {
+  @media (min-width: $media) {
+    .m-nav-links {
+      grid-template-columns: repeat(auto-fill, minmax($size, 1fr));
+    }
+  }
+}
+
+@media (min-width: 960px) {
+  .m-nav-links {
+    --m-nav-gap: 20px;
+  }
+}
+</style>

--- a/.vitepress/theme/components/FriendsBase.vue
+++ b/.vitepress/theme/components/FriendsBase.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { withBase } from 'vitepress'
+import { slugify } from '@mdit-vue/shared'
+
+import { FriendsLink } from '../types'
+
+const props = defineProps<{
+  noIcon?: boolean
+  icon?: FriendsLink['icon']
+  badge?: FriendsLink['badge']
+  title?: FriendsLink['title']
+  desc?: FriendsLink['desc']
+  link: FriendsLink['link']
+}>()
+
+const formatTitle = computed(() => {
+  if (!props.title) {
+    return ''
+  }
+  return slugify(props.title)
+})
+
+const svg = computed(() => {
+  if (typeof props.icon === 'object') return props.icon.svg
+  return ''
+})
+
+const formatBadge = computed(() => {
+  if (typeof props.badge === 'string') {
+    return { text: props.badge, type: 'info' }
+  }
+  return props.badge
+})
+</script>
+
+<template>
+  <a v-if="link" class="friends-link" :href="link" target="_blank" rel="noreferrer">
+    <article class="box" :class="{ 'has-badge': formatBadge }">
+      <div class="box-header">
+        <template v-if="!noIcon">
+          <div v-if="svg" class="icon" v-html="svg"></div>
+          <div v-else-if="icon && typeof icon === 'string'" class="icon">
+            <img
+              :src="withBase(icon)"
+              :alt="title"
+              onerror="this.parentElement.style.display='none'"
+            />
+          </div>
+        </template>
+        <h5 v-if="title" :id="formatTitle" class="title" :class="{ 'no-icon': noIcon }">
+          {{ title }}
+        </h5>
+      </div>
+      <Badge v-if="formatBadge" class="badge" :type="formatBadge.type" :text="formatBadge.text" />
+      <p v-if="desc" class="desc">{{ desc }}</p>
+    </article>
+  </a>
+</template>
+
+<style lang="scss" scoped>
+.friends-link {
+  --friends-icon-box-size: 40px;
+  --friends-icon-size: 24px;
+  --friends-box-gap: 12px;
+
+  display: block;
+  border: 1px solid var(--vp-c-bg-soft);
+  border-radius: 8px;
+  height: 100%;
+  // background-color: var(--vp-c-bg-soft);
+  background-color: rgba(0, 0, 0, 0.1);
+  text-decoration-line: none;
+  transition: all 0.25s;
+  &:hover {
+    box-shadow: var(--vp-shadow-2);
+    border-color: var(--vp-c-brand);
+    text-decoration: initial;
+    background-color: var(--vp-c-bg-soft-up);
+  }
+
+  .box {
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding: var(--friends-box-gap);
+    height: 100%;
+    color: var(--vp-c-text-1);
+    &.has-badge {
+      padding-top: calc(var(--friends-box-gap) + 2px);
+    }
+    &-header {
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  .icon {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    margin-right: calc(var(--friends-box-gap) - 2px);
+    border-radius: 6px;
+    width: var(--friends-icon-box-size);
+    height: var(--friends-icon-box-size);
+    font-size: var(--friends-icon-size);
+    background-color: var(--vp-c-bg-soft-down);
+    transition: background-color 0.25s;
+    :deep(svg) {
+      width: var(--friends-icon-size);
+      fill: currentColor;
+    }
+    :deep(img) {
+      border-radius: 4px;
+      width: var(--friends-icon-size);
+    }
+  }
+
+  .title {
+    overflow: hidden;
+    flex-grow: 1;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    font-size: 16px;
+    font-weight: 600;
+    &:not(.no-icon) {
+      line-height: var(--friends-icon-box-size);
+    }
+  }
+
+  .badge {
+    position: absolute;
+    top: 2px;
+    right: 0;
+    transform: scale(0.8);
+  }
+
+  .desc {
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex-grow: 1;
+    margin: calc(var(--friends-box-gap) - 2px) 0 0;
+    line-height: 1.5;
+    font-size: 12px;
+    color: var(--vp-c-text-2);
+  }
+}
+
+@media (max-width: 960px) {
+  .friends-link {
+    --friends-icon-box-size: 36px;
+    --friends-icon-size: 20px;
+    --friends-box-gap: 8px;
+
+    .title {
+      font-size: 14px;
+    }
+  }
+}
+</style>

--- a/.vitepress/theme/index.ts
+++ b/.vitepress/theme/index.ts
@@ -2,6 +2,7 @@
 import { h } from 'vue'
 import type { Theme } from 'vitepress'
 import DefaultTheme from 'vitepress/theme'
+import Friends from './components/Friends.vue'
 
 import './style.css'
 
@@ -13,6 +14,6 @@ export default {
     })
   },
   enhanceApp({ app, router, siteData }) {
-    // ...
+    app.component('Friends', Friends)
   },
 } satisfies Theme

--- a/.vitepress/theme/types.ts
+++ b/.vitepress/theme/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Represents a friend's link.
+ */
+export interface FriendsLink {
+  /**
+   * The icon associated with the link.
+   * It can be a string representing the icon name or an object with an SVG string.
+   */
+  icon?: string | { svg: string }
+
+  /**
+   * The badge associated with the link.
+   * It can be a string representing the badge text or an object with text and type properties.
+   */
+  badge?:
+    | string
+    | {
+        /**
+         * The text displayed on the badge.
+         */
+        text?: string
+
+        /**
+         * The type of the badge.
+         * It can be one of 'info', 'tip', 'warning', or 'danger'.
+         */
+        type?: 'info' | 'tip' | 'warning' | 'danger'
+      }
+
+  /**
+   * The title of the link.
+   */
+  title: string
+
+  /**
+   * The description of the link.
+   */
+  desc?: string
+
+  /**
+   * The URL of the link.
+   */
+  link: string
+}
+  
+export interface FriendsData {
+  title: string
+  items: FriendsLink[]
+}

--- a/articles/index.md
+++ b/articles/index.md
@@ -18,7 +18,7 @@ hero:
       link: /tech/tech
     - theme: alt
       text: Friends
-      link: /other/friends
+      link: /other/friends/index
     - theme: alt
       text: About me
       link: /other/about-me

--- a/articles/other/friends/data.ts
+++ b/articles/other/friends/data.ts
@@ -1,0 +1,16 @@
+import type { FriendsData } from '../../../.vitepress/theme/types'
+
+export const FRIENDS_DATA: FriendsData[] = [
+  {
+    // friend links data source
+    title: 'Friends',
+    items: [
+      {
+        icon: 'https://r2.toshiki.dev/image/toshiki-home-nuxt/06b8cbad3dc799e4bfe42c5d8bad2498.svg',
+        title: 'Toshiki\'s Homepage',
+        desc: 'Former full time INTP & current INTJ  & part time ISTP whom is caffein overdosed hyperboosted by Monster meanwhile an egoistic capitalist that overthinks ;)',
+        link: 'https://toshiki.dev'
+      },
+    ]
+  },
+]

--- a/articles/other/friends/index.md
+++ b/articles/other/friends/index.md
@@ -1,3 +1,10 @@
+<!-- importing friends list data -->
+<script setup>
+import { FRIENDS_DATA } from './data'
+</script>
+
+<Friends v-for="{title, items} in FRIENDS_DATA" :title="title" :items="items"/>
+
 # 我的朋友们
 
 ## 友链：

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "packageManager": "pnpm@9.0.4",
   "package-manager-strict": false,
   "devDependencies": {
+    "@mdit-vue/shared": "^2.1.2",
     "sass": "^1.75.0",
     "vitepress": "1.1.3",
     "vue": "^3.4.23"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 devDependencies:
+  '@mdit-vue/shared':
+    specifier: ^2.1.2
+    version: 2.1.2
   sass:
     specifier: ^1.75.0
     version: 1.75.0
@@ -448,6 +451,18 @@ packages:
     resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
     dev: true
 
+  /@mdit-vue/shared@2.1.2:
+    resolution: {integrity: sha512-5+YHKRyULDqMZsYq+8Ttev0P/osgAoNm2OPYrJtvxLfc1jyrZNiDUCjO2jec7Nk3qyGVZe6FKtXTNLVE+ZRhZw==}
+    dependencies:
+      '@mdit-vue/types': 2.1.0
+      '@types/markdown-it': 14.0.1
+      markdown-it: 14.1.0
+    dev: true
+
+  /@mdit-vue/types@2.1.0:
+    resolution: {integrity: sha512-TMBB/BQWVvwtpBdWD75rkZx4ZphQ6MN0O4QB2Bc0oI5PC2uE57QerhNxdRZ7cvBHE2iY2C+BUNUziCfJbjIRRA==}
+    dev: true
+
   /@rollup/rollup-android-arm-eabi@4.15.0:
     resolution: {integrity: sha512-O63bJ7p909pRRQfOJ0k/Jp8gNFMud+ZzLLG5EBWquylHxmRT2k18M2ifg8WyjCgFVdpA7+rI0YZ8EkAtg6dSUw==}
     cpu: [arm]
@@ -823,6 +838,10 @@ packages:
       picomatch: 2.3.1
     dev: true
 
+  /argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: true
+
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -954,6 +973,12 @@ packages:
     engines: {node: '>=0.12.0'}
     dev: true
 
+  /linkify-it@5.0.0:
+    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+    dependencies:
+      uc.micro: 2.1.0
+    dev: true
+
   /magic-string@0.30.10:
     resolution: {integrity: sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==}
     dependencies:
@@ -962,6 +987,22 @@ packages:
 
   /mark.js@8.11.1:
     resolution: {integrity: sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==}
+    dev: true
+
+  /markdown-it@14.1.0:
+    resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
+    hasBin: true
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.0
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+    dev: true
+
+  /mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
     dev: true
 
   /minisearch@6.3.0:
@@ -1007,6 +1048,11 @@ packages:
 
   /preact@10.20.2:
     resolution: {integrity: sha512-S1d1ernz3KQ+Y2awUxKakpfOg2CEmJmwOP+6igPx6dgr6pgDvenqYviyokWso2rhHvGtTlWWnJDa7RaPbQerTg==}
+    dev: true
+
+  /punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
     dev: true
 
   /readdirp@3.6.0:
@@ -1090,6 +1136,10 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: 7.0.0
+    dev: true
+
+  /uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
     dev: true
 
   /vite@5.2.9(sass@1.75.0):


### PR DESCRIPTION
Friend links formats, available values as follows with `icon`, `title`, `desc` & `link`, data sources are directly editable under the directory pf `articles/other/friends/data.ts`.
```ts
{
  icon: 'https://r2.toshiki.dev/image/toshiki-home-nuxt/06b8cbad3dc799e4bfe42c5d8bad2498.svg',
  title: 'Toshiki\'s Homepage',
  desc: 'Former full time INTP & current INTJ  & part time ISTP whom is caffein overdosed hyperboosted by Monster meanwhile an egoistic capitalist that overthinks ;)',
  link: 'https://toshiki.dev'
},
```